### PR TITLE
 Fix getting argument value with the correct name and parsing the value from json number

### DIFF
--- a/complexity.go
+++ b/complexity.go
@@ -2,6 +2,7 @@
 package complexity
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -166,11 +167,18 @@ func getConnectionNodeCount(args types.ArgumentList, variables map[string]interf
 			case *types.PrimitiveValue:
 				itemCount, _ = strconv.Atoi(arg.String())
 			case *types.Variable:
-				variableValue, ok := variables[a.Name.Name]
+
+				variableValue, ok := variables[arg.Name]
 				if !ok {
 					return 0, fmt.Errorf("Variable %s not defined", a.Name.Name)
 				}
+
 				switch i := variableValue.(type) {
+				case json.Number:
+					value, err := i.Int64()
+					if err == nil {
+						itemCount = int(value)
+					}
 				case float64:
 					itemCount = int(i)
 				case float32:

--- a/complexity_test.go
+++ b/complexity_test.go
@@ -1,6 +1,7 @@
 package complexity_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,6 +44,20 @@ func TestGetQueryComplexity(t *testing.T) {
 			  }`,
 			variables:      map[string]interface{}{"first": float64(5)},
 			wantComplexity: 7,
+		},
+		{
+			name: "Connection with 1005 items using a variable with other name, and json value",
+			query: `query GetGroups($arg: Int){
+				groups(first: $arg, sort: FULL_PATH_ASC) {
+				  edges {
+					node {
+					  id
+					}
+				  }
+				}
+			  }`,
+			variables:      map[string]interface{}{"arg": json.Number("1005")},
+			wantComplexity: 1007,
 		},
 		{
 			name: "query with nested fragments",


### PR DESCRIPTION
1. Fix getting argument value with the correct name.
Before the fix the code was looking in the variables map with with the name of the graphql field, and not the name of the variable. That only worked as long as the variable name is the same as the field name.

2. Fix getting argument value which was parsed from json as a number.
This is a common case that several graphql libraries would cause.

Includes a test for both cases.
